### PR TITLE
Fixes #11

### DIFF
--- a/Massage Parlour/index.css
+++ b/Massage Parlour/index.css
@@ -73,12 +73,12 @@ header::before {
 
 .chyron p {
     width: 100%;
-    margin-top: 0px;
+    margin-top: auto;
+    margin-bottom: auto;
     font-size: small;
 }
 
 .chyron>p {
-    /* color: #fff; */
     font-size: 1.25rem;
     animation-name: chyron-slide;
     animation-duration: 20s;
@@ -208,6 +208,7 @@ input[type=submit] {
     height: 50px;
     cursor: pointer;
     color: aliceblue;
+    font-weight: bold;
     font-size: 20px;
     background: orangered;
 }

--- a/Massage Parlour/landingpage.html
+++ b/Massage Parlour/landingpage.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link rel="stylesheet" href="index.css">
+    <link rel="stylesheet" href="media.css">
 
     <!-- Font Awesome -->
     <link rel="stylesheet"

--- a/Massage Parlour/media.css
+++ b/Massage Parlour/media.css
@@ -1,5 +1,9 @@
 @media screen and (max-width: 1115px) {
-    
+
+    /* Testimonials */
+    .testimony {
+        margin-top: 25px;
+    }
 }
 
 
@@ -8,6 +12,27 @@
 
 @media screen and (max-width: 992px) {
 
+    /* Header */
+    #logo {
+        font-size: 30px;
+    }
+
+    menu {
+        width: 60%;
+        font-size: 20px;
+    }
+
+    /* Bookings */
+
+    .booking {
+        width: 80%;
+    }
+
+    /* Testimonials */
+
+    .testimony {
+        margin: 20px;
+    }
 }
 
 
@@ -15,8 +40,64 @@
 
 
 @media screen and (max-width: 767px) {
+    /* Chyron */
 
+    .chyron {
+        justify-content: space-evenly;
+    }
+
+    .chyron p {
+        width: 100%;
+        font-size: 12.5px;
+    }
+
+    /* Header */
+    nav {
+        flex-wrap: wrap;
+    }
+
+    #logo {
+        width: 100%;
+        text-align: center;
+    }
+
+    menu {
+        width: 100%;
+        justify-content: space-around;
+        padding: 0;
+        margin-left: auto;
+        margin-right: auto;
+    }
+
+    .head-message h2 {
+        font-size: 25px;
+    }
+
+    .head-message p {
+        font-size: 18px;
+    }
+
+
+    /* Bookings */
+
+    .booking {
+        width: 90%;
+    }
+
+    input[type=submit] {
+        width: 50%;
+        height: 40px;
+        font-size: 15px;
+    }
+
+
+    /* Testimonials */
+
+    .testimony {
+        margin: 15px;
+    }
 }
+
 
 
 
@@ -24,12 +105,44 @@
 
 @media screen and (max-width: 479px) {
 
-}
+    /* Chyron */
 
+    .chyron p {
+        font-size: 9px;
+    }
 
+    /* Header */
 
+    .head-message {
+        width: auto;
+    }
 
+    .head-message h2 {
+        font-size: 20px;
+        text-align: center;
+    }
 
-@media screen and (max-width: 360px) {
+    .head-message p {
+        font-size: 15px;
+        text-align: center;
+    }
 
+    nav button {
+        height: 30px;
+        width: 70px;
+    }
+
+    menu {
+        font-size: 15px;
+    }
+
+    /* Bookings */
+
+    .form-img {
+        display: none;
+    }
+
+    form {
+        width: 100%;
+    }
 }


### PR DESCRIPTION
# Made Webpage Responsive

## What changes were made?
* Gave the paragraph inside the `.chyron` div a margin-top and bottom of `auto` in the index.css file
* In the media.css file:
  * At the 1115px breakpoint:
    * The `.testimony` divs were given a margin-top of 20px
  * At the 992px breakpoint:
    * The `#logo` link was given a font size of 30px
    * The `menu` tag was given a width of 60% and font size of 20px
    * The `.booking` div was given a width of 80%
    * The `.testimony` div was given a margin of 20px
  * At the 767px breakpoint:
    * Gave the paragraph inside the `.chyron` a font size of 12.5px
    * Gave the `nav` a flex-wrap of `wrap`
    * The `#logo` link was given a width of 100% and the text was aligned to the center
    * The `menu` was given a width of 100%, justify content of `space-around`, padding of 0 and margin left and right of `auto`
    * The `p` and `h2` tags inside of the `.head-message` div were set to 18px and 25px, respectively.
    * The `.bookings` div was given a width of 90%
    * The submit button was given a height and width of 40px and 50% and font size of 15px.
    * The `.testimony` div was given a margin of 15px
  * At the 479px breakpoint:
    * The `p` inside of the `.chyron` was given a font size of 9px
    * The `.head-message` was given a width of auto
    * The `p` and `h2` inside the `.head-message` div were given a central text alignment and font size of 20px and 15px
    * The button inside of the `nav` was given a height and width of 30px and 70px respectively
    * The `menu` was given a font size of 15px
    * The `.form-img` was removed and the width of the form was set to 100%



## Why were the changes made?
* The margin top and bottom in the index.css file was done to vertically center the text in the paragraph tag, so it is not too high or low on all media breakpoints
* In the media.css file:
  * At the 1115px breakpoint:
    * The `.testimony` divs were given the new margin-top to make sure they are not too close together at a smaller screen width when they eventually start being aligned with one above the other because of the `flex-wrap` property of the `.testimonials` div.
  * At the 992px breakpoint:
    * The `#logo` link was given a font size of 30px so it does not take up too much space and crowd out the other elements in the `nav`
    * The width given to the `menu` tag was done to make it take up a bit more space and the change in font size was done to make the text inside of it slightly smaller and not to be too bunched up together
    * The width given to the `.booking` div was to make it take up a bit more space and make that part of the webpage look less empty
    * The margin given to the `.testimony` divs was done to make them less bunched up when they are next to each other as the screen width shrinks
  * At the 767px breakpoint:
    * The font size given to the paragraph inside the `.chyron` div was done to make the text take up less space and prevent text from going over into the next line
    * The `nav` was given its flex-wrap to make sure the text moves over onto the next line when, in particular, the text inside the `menu` tag, while leaving the `#logo` tag on its above the `menu` tag
    * The width of the `#logo` was set to 100% so it can take up all of the horizontal space so it can move the `menu` onto a new line below it and therefore also allowing the logo to be shown at lower screen sizes without having to shrink its font size until it is necessary.
    * The `menu` was given its width so it also takes up all the width allowing its text to take up enough space and not bunch up the text or require smaller font sizes until required, the change to the padding helps with the alignment of the text inside of it being central along with the margin left and right properties
    * The font sizes given to the  `p` and `h2` tags inside of the `.head-message` div were done so they do not take up too much space and either overlap or underlap other elements
    * The width given to the `.booking` div was done to make it take up a bit more space and prevent the quality of the image nested inside of it from deteriorating.
    * The height and width given to the submit button was done to make it take up less space in the form and the same was done regarding the font size in relation to the rest of the button which houses it.
    * The margin given to the `.testimony` divs was done to keep them separated at smaller screen widths, but not as much as on a higher screen width
  * At the 479px breakpoint:
    * The font size given to the `p` inside of the `.chyron` was done to make it take up less space at a smaller screen size and prevent the text from breaking off into the next line.
    * The width given to the `.head-message` was done to make sure that it has enough width to house the text within it while preventing it from overflowing from its originally allotted space at the current screen width.
    * The font size given to the `p` and `h2` inside of the `.head-message` was done to prevent it from being too big for the screen size and overlapping other content on the page
    * The height and width given to the button inside of the `nav` was done to make sure it does not take up too much space and also fall out of alignment with the rest of the elements that are alongside it in the `menu` tag
    * The font size given to the `menu` was done to prevent the text from taking up too much space and being bunched up too closely
    * The `.form-img` was removed because I could not find a way to include it and resorted to making the form take up the rest of the space in the `.booking` div.



## Future Improvements
* Remove the justify content for the `.chyron` at the 767px breakpoint because it no longer works after nesting all the spans inside the `p` tag and instead apply it to the `p` tag nested inside the `.chyron` div in the index.css file and remove the spacings that were placed in the landingpage.html file.
* Remove the width property given to the paragraph inside the `.chyron` div at the 767px because the exact same value was given to it at in the index.css file
* To make up for the removal of the of the `.form-img`, a slide show could be included below or above it, or I could find a way to include it as was done at higher screen sizes.
