### PR TITLE
Fixes #17

### DIFF
--- a/Massage Parlour/index.css
+++ b/Massage Parlour/index.css
@@ -30,34 +30,11 @@ footer {
 /* Header */
 
 header {
-    position: relative;
     height: 400px;
     background-size: auto;
     background-repeat: no-repeat;
     background-position: center center;
     background-image: url(https://images.unsplash.com/photo-1595871151608-bc7abd1caca3?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D);
-    z-index: -5;
-    /* Makes sure the overlay does not overlay the child elements */
-}
-
-header * {
-    z-index: 10;
-    /* Makes sure all elements are above their parent element and the
-    ::after pseudo element */
-}
-
-header::before {
-    background-color: rgba(41, 40, 40, 0.35);
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    /* The above makes sure the overlay is seen above the header */
-    z-index: -5;
-    /* Makes sure the overlay does not overlay the child elements
-    of the header */
 }
 
 .chyron {
@@ -132,6 +109,7 @@ nav button {
 }
 
 menu {
+    position: relative;
     display: flex;
     justify-content: space-evenly;
     width: 50%;


### PR DESCRIPTION
# Removed pseudo element overlay

## What changes were made?
* I removed the `::before` pseudo element from the header and removed the relative positioning from the header
* I also removed the declaration for all the elements nested under the header

## Why were the changes made?
* The relative positioning of the header was preventing the anchor tags from being accessed, so removing it changed that, but it made the overlay redundant, and it also had to be removed since it would require a lot more work to make it work without the relative position of the header
* All the other code that was removed was done because it also would not be needed because of the removal of the pseudo element for the header
